### PR TITLE
Use hosts's network stack by passing `--network=host` to `docker run`

### DIFF
--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -25,7 +25,7 @@ public class DockerService : IDockerService
     {
         var actionsImporterArguments = new List<string>
         {
-            "run --rm -t"
+            "run --rm -t --network=host"
         };
         actionsImporterArguments.AddRange(GetEnvironmentVariableArguments());
 


### PR DESCRIPTION
Without using the host's network stack, the container may behave unexpectedly, such as failing to resolve internal addresses that the host _can_ resolve.

## What's changing?

The way that the Docker container networks will change. The Docker container will use the host's network stack to make network requests. This, in theory, shouldn't break anything.

## How's this tested?

It hasn't been tested.
